### PR TITLE
Added get-server command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(googleLibs.secretsManager)
 
     // TODO: move to library
-    implementation(platform("software.amazon.awssdk:bom:2.21.1"))
+    implementation(platform("software.amazon.awssdk:bom:2.23.11"))
     implementation("software.amazon.awssdk:aws-core")
     implementation("software.amazon.awssdk:ec2")
 

--- a/src/main/kotlin/com/tubefans/gamepicker/commands/GetServerCommand.kt
+++ b/src/main/kotlin/com/tubefans/gamepicker/commands/GetServerCommand.kt
@@ -1,0 +1,37 @@
+package com.tubefans.gamepicker.commands
+
+import com.tubefans.gamepicker.extensions.getStringOption
+import com.tubefans.gamepicker.extensions.toDisplayString
+import com.tubefans.gamepicker.services.EC2Service
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class GetServerCommand @Autowired constructor(
+    private val ec2Service: EC2Service
+) : SlashCommand {
+    companion object {
+        const val NAME_KEY = "name"
+        const val ERROR_TEMPLATE = "Failed to get instance status for %s: %s, %s"
+    }
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    override val name = "get-server"
+
+    override fun handle(event: ChatInputInteractionEvent): Mono<Void> {
+        val serverName = event.getStringOption(NAME_KEY)
+        return event.deferReply()
+            .then(ec2Service.getInstanceStatus(serverName))
+            .map { status ->
+                status.toDisplayString(serverName)
+            }.onErrorResume { e ->
+                logger.error("Uncaught exception getting instance status", e)
+                Mono.just(String.format(ERROR_TEMPLATE, serverName, e::class.simpleName, e.message))
+            }.flatMap { message ->
+                event.editReply(message)
+            }.then()
+    }
+}

--- a/src/main/kotlin/com/tubefans/gamepicker/extensions/AWSExtensionFunctions.kt
+++ b/src/main/kotlin/com/tubefans/gamepicker/extensions/AWSExtensionFunctions.kt
@@ -1,0 +1,21 @@
+package com.tubefans.gamepicker.extensions
+
+import software.amazon.awssdk.services.ec2.model.InstanceStatus
+
+val STATUS_TEMPLATE_STRING: String = """
+            ```
+            Name: %s
+            ID: %s
+            Summary: %s
+            State: %s
+            ```
+""".trimIndent()
+
+fun InstanceStatus.toDisplayString(serverName: String): String =
+    String.format(
+        STATUS_TEMPLATE_STRING,
+        serverName,
+        this.instanceId(),
+        this.instanceStatus(),
+        this.instanceState()
+    )

--- a/src/main/kotlin/com/tubefans/gamepicker/listeners/CommandListener.kt
+++ b/src/main/kotlin/com/tubefans/gamepicker/listeners/CommandListener.kt
@@ -6,7 +6,6 @@ import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
 import org.apache.logging.log4j.LogManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import reactor.core.publisher.Mono
 
 @Component
 final class CommandListener @Autowired constructor(
@@ -19,11 +18,12 @@ final class CommandListener @Autowired constructor(
     init {
         logger.info("Subscribing to commands: ${commands.joinToString { it.name }}")
         client.on(ChatInputInteractionEvent::class.java, this::handle)
+            .doOnEach {
+                System.gc() // ¯\_(ツ)_/¯ blame Connor
+            }
             .subscribe()
     }
 
-    private fun handle(event: ChatInputInteractionEvent): Mono<Void> {
-        logger.info("Handling event {}", event.commandName)
-        return commands.first { it.name == event.commandName }.handle(event)
-    }
+    private fun handle(event: ChatInputInteractionEvent) =
+        commands.first { it.name == event.commandName }.handle(event)
 }

--- a/src/main/kotlin/com/tubefans/gamepicker/services/ChatInputInteractionEventService.kt
+++ b/src/main/kotlin/com/tubefans/gamepicker/services/ChatInputInteractionEventService.kt
@@ -2,6 +2,7 @@ package com.tubefans.gamepicker.services
 
 import com.tubefans.gamepicker.dto.DiscordUser
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.entity.channel.MessageChannel
 import discord4j.core.`object`.entity.channel.VoiceChannel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.filter
@@ -21,6 +22,9 @@ class ChatInputInteractionEventService @Autowired constructor(
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
+
+    fun getCommandMessageChannel(event: ChatInputInteractionEvent): Mono<MessageChannel> =
+        event.interaction.channel
 
     fun getCurrentChannel(event: ChatInputInteractionEvent): VoiceChannel? =
         event.interaction.member.get()

--- a/src/main/kotlin/com/tubefans/gamepicker/services/EC2Service.kt
+++ b/src/main/kotlin/com/tubefans/gamepicker/services/EC2Service.kt
@@ -4,9 +4,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
+import software.amazon.awssdk.awscore.exception.AwsServiceException
 import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
 import software.amazon.awssdk.services.ec2.model.Ec2Exception
+import software.amazon.awssdk.services.ec2.model.InstanceStatus
 import software.amazon.awssdk.services.ec2.model.StartInstancesRequest
 import software.amazon.awssdk.services.ec2.model.StopInstancesRequest
 
@@ -21,50 +25,74 @@ constructor(
 
     val instanceMap: MutableMap<String, String> = HashMap()
 
-    fun startInstance(name: String): String {
-        val instanceId = instanceMap[name.lowercase()] ?: throw NoSuchElementException("No instance found with name $name")
+    fun startInstance(name: String): Mono<String> =
+        Mono.fromCallable {
+            val instanceId =
+                instanceMap[name.lowercase()] ?: throw NoSuchElementException("No instance found with name $name")
 
-        val startRequest = StartInstancesRequest.builder().instanceIds(instanceId).build()
+            val startRequest = StartInstancesRequest.builder().instanceIds(instanceId).build()
 
-        val startingInstances =
-            ec2Client.startInstances(startRequest)
-                .startingInstances()
-                .map { it.instanceId() }
+            val startingInstances =
+                ec2Client.startInstances(startRequest)
+                    .startingInstances()
+                    .map { it.instanceId() }
 
-        logger.debug("starting instances: ${startingInstances.joinToString(",")}")
+            logger.debug("starting instances: ${startingInstances.joinToString(",")}")
 
-        if (!startingInstances.contains(instanceId)) {
-            throwEc2Exception("Failed to start instance with name $name and id $instanceId")
+            if (!startingInstances.contains(instanceId)) {
+                throw ec2Exception("Failed to start instance with name $name and id $instanceId")
+            }
+
+            val describeRequest = DescribeInstancesRequest.builder().instanceIds(instanceId).build()
+            val describeResponse = ec2Client.describeInstances(describeRequest)
+
+            if (describeResponse.reservations().isEmpty() ||
+                !describeResponse.reservations()[0].hasInstances()
+            ) {
+                logger.warn("reservations: ${describeResponse.reservations().joinToString(",")}")
+                throw ec2Exception("Failed to get starting instances")
+            }
+            val ip = describeResponse.reservations()[0].instances()[0].publicIpAddress()
+            logger.debug("Starting instance at $ip")
+            ip
         }
 
-        val describeRequest = DescribeInstancesRequest.builder().instanceIds(instanceId).build()
-        val describeResponse = ec2Client.describeInstances(describeRequest)
+    fun stopInstance(name: String): Mono<String> =
+        Mono.fromCallable {
+            val instanceId = instanceMap[name.lowercase()]
+                ?: throw NoSuchElementException("No instance found with name $name")
 
-        if (describeResponse.reservations().isEmpty() ||
-            !describeResponse.reservations()[0].hasInstances()
-        ) {
-            logger.warn("reservations: ${describeResponse.reservations().joinToString(",")}")
-            throwEc2Exception("Failed to get starting instances")
+            val stopRequest = StopInstancesRequest.builder().instanceIds(instanceId).build()
+            val stoppingInstances = ec2Client.stopInstances(stopRequest).stoppingInstances().map { it.instanceId() }
+            logger.debug("stopping instances: ${stoppingInstances.joinToString(",")}")
+            if (!stoppingInstances.contains(instanceId)) {
+                throw ec2Exception("Failed to stop instance with name $name and id $instanceId")
+            }
+            instanceId
         }
-        val ip = describeResponse.reservations()[0].instances()[0].publicIpAddress()
-        logger.debug("Starting instance at $ip")
-        return ip
-    }
 
-    fun stopInstance(name: String) {
-        val instanceId = instanceMap[name.lowercase()] ?: throw NoSuchElementException("No instance found with name $name")
+    fun getInstanceStatus(name: String): Mono<InstanceStatus> =
+        Mono.fromCallable {
+            val instanceId =
+                instanceMap[name.lowercase()] ?: throw NoSuchElementException("No instance found with name $name")
 
-        val stopRequest = StopInstancesRequest.builder().instanceIds(instanceId).build()
-        val stoppingInstances = ec2Client.stopInstances(stopRequest).stoppingInstances().map { it.instanceId() }
-        logger.debug("stopping instances: ${stoppingInstances.joinToString(",")}")
-        if (!stoppingInstances.contains(instanceId)) {
-            throwEc2Exception("Failed to stop instance with name $name and id $instanceId")
+            logger.debug("describing instance $instanceId")
+            val describeInstanceStatusRequest = DescribeInstanceStatusRequest.builder()
+                .instanceIds(instanceId)
+                .includeAllInstances(true)
+                .build()
+            val describeResponse = ec2Client.describeInstanceStatus(describeInstanceStatusRequest)
+
+            if (!describeResponse.hasInstanceStatuses() || describeResponse.instanceStatuses().isEmpty()) {
+                throw ec2Exception("Failed to get instance status for instance with name $name and id $instanceId")
+            }
+
+            logger.debug("state: {}", describeResponse.instanceStatuses()[0].instanceState())
+            describeResponse.instanceStatuses()[0]
         }
-    }
 
-    private fun throwEc2Exception(message: String) {
-        throw Ec2Exception.builder()
+    private fun ec2Exception(message: String): AwsServiceException =
+        Ec2Exception.builder()
             .message(message)
             .build()
-    }
 }

--- a/src/main/resources/commands/get-server.json
+++ b/src/main/resources/commands/get-server.json
@@ -1,0 +1,12 @@
+{
+  "name": "get-server",
+  "description": "Gets info on an EC2 instance",
+  "options": [
+    {
+      "name": "name",
+      "description": "Name of the instance. Valid options are palworld and dsc",
+      "type": 3,
+      "required": true
+    }
+  ]
+}

--- a/src/test/kotlin/com/tubefans/gamepicker/commands/GetServerCommandTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/commands/GetServerCommandTest.kt
@@ -1,0 +1,70 @@
+package com.tubefans.gamepicker.commands
+
+import com.tubefans.gamepicker.commands.GetServerCommand.Companion.ERROR_TEMPLATE
+import com.tubefans.gamepicker.extensions.toDisplayString
+import com.tubefans.gamepicker.services.EC2Service
+import com.tubefans.gamepicker.testlibrary.infra.Discord4JEventTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import reactor.core.publisher.Mono
+import software.amazon.awssdk.services.ec2.model.InstanceStatus
+
+class GetServerCommandTest : Discord4JEventTest() {
+    private val serverName = "name1"
+    private val serverId = "id1"
+    private val mockMap = mutableMapOf(Pair(serverName, serverId))
+    private val mockService: EC2Service = mockk {
+        every { instanceMap } returns mockMap
+    }
+    private val command = GetServerCommand(mockService)
+
+    private val instanceStatusString = "instance status"
+    private val instanceStateString = "instance state"
+    private val mockStatus: InstanceStatus = mockk {
+        every { instanceId() } returns serverId
+        every { instanceStatus() } returns mockk {
+            every { this@mockk.toString() } returns instanceStatusString
+        }
+        every { instanceState() } returns mockk {
+            every { this@mockk.toString() } returns instanceStateString
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        Mockito.`when`(optionValue.asString()).thenReturn(serverName)
+        Mockito.`when`(option.name).thenReturn("name")
+        every { mockService.instanceMap }
+    }
+
+    @Test
+    fun `should get server status`() {
+        val expectedMessage = mockStatus.toDisplayString(serverName)
+        every { mockService.getInstanceStatus(serverName) } returns Mono.just(mockStatus)
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.getInstanceStatus(serverName) }
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
+    }
+
+    @Test
+    fun `should display error message if getInstanceStatus() fails`() {
+        val exceptionMessage = "Exception message"
+        val exceptionClass = RuntimeException::class.simpleName
+        val expectedMessage = String.format(ERROR_TEMPLATE, serverName, exceptionClass, exceptionMessage)
+        every { mockService.getInstanceStatus(serverName) } returns Mono.error(RuntimeException(exceptionMessage))
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.getInstanceStatus(serverName) }
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
+    }
+}

--- a/src/test/kotlin/com/tubefans/gamepicker/commands/StartCommandTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/commands/StartCommandTest.kt
@@ -16,7 +16,7 @@ import org.mockito.Mockito.`when`
 import reactor.core.publisher.Mono
 import software.amazon.awssdk.awscore.exception.AwsServiceException
 
-class StartServiceTest : Discord4JEventTest() {
+class StartCommandTest : Discord4JEventTest() {
     private val serverName = "name1"
 
     private val mockMap = mutableMapOf(Pair(serverName, "id1"))

--- a/src/test/kotlin/com/tubefans/gamepicker/commands/StartServiceTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/commands/StartServiceTest.kt
@@ -1,48 +1,95 @@
 package com.tubefans.gamepicker.commands
 
 import com.tubefans.gamepicker.services.EC2Service
+import com.tubefans.gamepicker.testlibrary.infra.Discord4JEventTest
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono
+import discord4j.core.spec.InteractionReplyEditMono
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.atMostOnce
+import org.mockito.Mockito.times
+import org.mockito.Mockito.`when`
+import reactor.core.publisher.Mono
 import software.amazon.awssdk.awscore.exception.AwsServiceException
 
-class StartServiceTest {
-    private val mockMap = mutableMapOf(Pair("name1", "id1"))
+class StartServiceTest : Discord4JEventTest() {
+    private val serverName = "name1"
+
+    private val mockMap = mutableMapOf(Pair(serverName, "id1"))
     private val mockService: EC2Service = mockk() {
         every { instanceMap } returns mockMap
     }
     private val command = StartServerCommand(mockService)
 
+    private val ip = "ip address"
+
+    @BeforeEach
+    fun setup() {
+        `when`(optionValue.asString()).thenReturn(serverName)
+        `when`(option.name).thenReturn("name")
+    }
+
     @Test
     fun `should return ip when starting server`() {
-        val serverName = "name1"
-        val ip = "ip address"
-        every { mockService.startInstance(serverName) } returns ip
+        val expectedMessage = "Starting instance at ip address: $ip"
+        every { mockService.startInstance(serverName) } returns Mono.just(ip)
 
-        assertEquals("Starting instance at ip address: $ip", command.startServer(serverName))
+        command.handle(inputEvent).block()
+
         verify(exactly = 1) { mockService.startInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).options
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
     }
 
     @Test
     fun `should return relevant error message when instance fails to start`() {
-        val serverName = "name1"
         val errorMessage = "error message"
-        every { mockService.startInstance(serverName) } throws AwsServiceException.builder().message(errorMessage)
-            .build()
+        val expectedMessage = "Failed to start instance: $errorMessage"
+        every { mockService.startInstance(serverName) }.returns(
+            Mono.error(
+                AwsServiceException.builder()
+                    .message(errorMessage)
+                    .build()
+            )
+        )
 
-        assertEquals("Failed to start instance: $errorMessage", command.startServer(serverName))
+        `when`(inputEvent.options).thenReturn(listOf(option))
+        `when`(inputEvent.deferReply()).thenReturn(InteractionCallbackSpecDeferReplyMono.of(inputEvent))
+        `when`(inputEvent.editReply(expectedMessage)).thenReturn(InteractionReplyEditMono.of(inputEvent))
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.startInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).options
+        Mockito.verify(inputEvent, atMostOnce()).deferReply()
+        Mockito.verify(inputEvent, atMostOnce()).editReply(expectedMessage)
     }
 
     @Test
     fun `should return relevant error message when server name is not found`() {
-        val serverName = "name1"
         val nameString = mockMap.keys.joinToString(",")
         val expectedMessage = "Failed to find EC2 instance associated with $serverName. Valid values are: $nameString"
 
-        every { mockService.startInstance(serverName) } throws NoSuchElementException()
+        every { mockService.startInstance(serverName) }.returns(
+            Mono.error(
+                NoSuchElementException()
+            )
+        )
 
-        assertEquals(expectedMessage, command.startServer(serverName))
+        `when`(inputEvent.options).thenReturn(listOf(option))
+        `when`(inputEvent.deferReply()).thenReturn(InteractionCallbackSpecDeferReplyMono.of(inputEvent))
+        `when`(inputEvent.editReply(expectedMessage)).thenReturn(InteractionReplyEditMono.of(inputEvent))
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.startInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).options
+        Mockito.verify(inputEvent, atMostOnce()).deferReply()
+        Mockito.verify(inputEvent, atMostOnce()).editReply(expectedMessage)
     }
 }

--- a/src/test/kotlin/com/tubefans/gamepicker/commands/StopCommandTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/commands/StopCommandTest.kt
@@ -1,0 +1,96 @@
+package com.tubefans.gamepicker.commands
+
+import com.tubefans.gamepicker.commands.StopServerCommand.Companion.AWS_ERROR_TEMPLATE
+import com.tubefans.gamepicker.services.EC2Service
+import com.tubefans.gamepicker.testlibrary.infra.Discord4JEventTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.`when`
+import reactor.core.publisher.Mono
+import software.amazon.awssdk.awscore.exception.AwsServiceException
+
+class StopCommandTest : Discord4JEventTest() {
+    private val serverName = "name1"
+    private val serverId = "id1"
+    private val mockMap = mutableMapOf(Pair(serverName, serverId))
+    private val mockService: EC2Service = mockk() {
+        every { instanceMap } returns mockMap
+    }
+
+    private val command = StopServerCommand(mockService)
+
+    @BeforeEach
+    fun setup() {
+        `when`(optionValue.asString()).thenReturn(serverName)
+        `when`(option.name).thenReturn("name")
+    }
+
+    @Test
+    fun `should call stopInstance()`() {
+        val expectedMessage = "Stopping $serverName running on $serverId"
+        every { mockService.stopInstance(serverName) } returns Mono.just(serverId)
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.stopInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
+    }
+
+    @Test
+    fun `should propagate exceptions from ec2client`() {
+        val exceptionMessage = "exception message"
+        val expectedMessage =
+            String.format(AWS_ERROR_TEMPLATE, serverName, AwsServiceException::class.simpleName, exceptionMessage)
+        every { mockService.stopInstance(serverName) } returns Mono.error(
+            AwsServiceException.builder().message(exceptionMessage).build()
+        )
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.stopInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
+    }
+
+    @Test
+    fun `should respond with appropriate error message when serverName is not found`() {
+        val expectedMessage =
+            String.format(StopServerCommand.SERVER_NOT_FOUND_TEMPLATE, serverName, mockMap.keys.joinToString(","))
+        every { mockService.stopInstance(serverName) } returns Mono.error(
+            NoSuchElementException()
+        )
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.stopInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
+    }
+
+    @Test
+    fun `should respond with appropriate message for uncaught exceptions`() {
+        val exceptionMessage = "exception message"
+        val expectedMessage =
+            String.format(
+                StopServerCommand.UNHANDLED_ERROR_TEMPLATE,
+                serverName,
+                RuntimeException::class.simpleName,
+                exceptionMessage
+            )
+        every { mockService.stopInstance(serverName) } returns Mono.error(
+            RuntimeException(exceptionMessage)
+        )
+
+        command.handle(inputEvent).block()
+
+        verify(exactly = 1) { mockService.stopInstance(serverName) }
+        Mockito.verify(inputEvent, times(1)).deferReply()
+        Mockito.verify(inputEvent, times(1)).editReply(expectedMessage)
+    }
+}

--- a/src/test/kotlin/com/tubefans/gamepicker/commands/StopServiceTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/commands/StopServiceTest.kt
@@ -1,3 +1,0 @@
-package com.tubefans.gamepicker.commands
-
-class StopServiceTest

--- a/src/test/kotlin/com/tubefans/gamepicker/services/EC2ServiceTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/services/EC2ServiceTest.kt
@@ -228,14 +228,14 @@ class EC2ServiceTest {
         assertEquals(mockInstanceStatus, service.getInstanceStatus(serverName).block())
     }
 
-   @Test
-   fun `should throw NoSuchElementException if serverName doesn't match any known servers`() {
-       assertThrows(NoSuchElementException::class.java) {
-           service.getInstanceStatus("not a server").block()
-       }
+    @Test
+    fun `should throw NoSuchElementException if serverName doesn't match any known servers`() {
+        assertThrows(NoSuchElementException::class.java) {
+            service.getInstanceStatus("not a server").block()
+        }
 
-       verify { mockEc2Client wasNot Called }
-   }
+        verify { mockEc2Client wasNot Called }
+    }
 
     @Test
     fun `should propagate exception if describeInstanceStatus() fails`() {
@@ -245,7 +245,7 @@ class EC2ServiceTest {
             .build()
 
         every { mockEc2Client.describeInstanceStatus(eq(expectedRequest)) } throws
-                AwsServiceException.builder().build()
+            AwsServiceException.builder().build()
 
         assertThrows(AwsServiceException::class.java) {
             service.getInstanceStatus(serverName).block()

--- a/src/test/kotlin/com/tubefans/gamepicker/services/EC2ServiceTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/services/EC2ServiceTest.kt
@@ -58,7 +58,7 @@ class EC2ServiceTest {
                 every { reservations() } returns listOf(mockReservation)
             }
 
-        assertEquals(ip, service.startInstance(serverName))
+        assertEquals(ip, service.startInstance(serverName).block())
     }
 
     @Test
@@ -89,7 +89,7 @@ class EC2ServiceTest {
                 every { reservations() } returns listOf(mockReservation)
             }
 
-        assertEquals(ip, service.startInstance(serverName.uppercase()))
+        assertEquals(ip, service.startInstance(serverName.uppercase()).block())
     }
 
     @Test
@@ -116,7 +116,7 @@ class EC2ServiceTest {
             }
 
         assertThrows(Ec2Exception::class.java) {
-            service.startInstance(serverName)
+            service.startInstance(serverName).block()
         }
     }
 
@@ -133,7 +133,7 @@ class EC2ServiceTest {
             }
 
         assertThrows(Ec2Exception::class.java) {
-            service.startInstance(serverName)
+            service.startInstance(serverName).block()
         }
     }
 
@@ -143,14 +143,14 @@ class EC2ServiceTest {
             .build()
 
         assertThrows(AwsServiceException::class.java) {
-            service.startInstance(serverName)
+            service.startInstance(serverName).block()
         }
     }
 
     @Test
     fun `should throw NoSuchElementException when calling startInstance() if map doesn't contain name`() {
         assertThrows(NoSuchElementException::class.java) {
-            service.startInstance("aaa")
+            service.startInstance("aaa").block()
         }
     }
 
@@ -166,7 +166,7 @@ class EC2ServiceTest {
             every { stoppingInstances() } returns listOf(mockInstance)
         }
 
-        assertDoesNotThrow { service.stopInstance(serverName) }
+        assertDoesNotThrow { service.stopInstance(serverName).block() }
     }
 
     @Test
@@ -181,7 +181,7 @@ class EC2ServiceTest {
             every { stoppingInstances() } returns listOf(mockInstance)
         }
 
-        assertDoesNotThrow { service.stopInstance(serverName.uppercase()) }
+        assertDoesNotThrow { service.stopInstance(serverName.uppercase()).block() }
     }
 
     @Test
@@ -191,14 +191,14 @@ class EC2ServiceTest {
         }
 
         assertThrows(Ec2Exception::class.java) {
-            service.stopInstance(serverName)
+            service.stopInstance(serverName).block()
         }
     }
 
     @Test
     fun `should throw NoSuchElementException when calling stopInstance() if map doesn't contain name`() {
         assertThrows(NoSuchElementException::class.java) {
-            service.stopInstance("aaa")
+            service.stopInstance("aaa").block()
         }
     }
 }

--- a/src/test/kotlin/com/tubefans/gamepicker/testlibrary/infra/Discord4JEventTest.kt
+++ b/src/test/kotlin/com/tubefans/gamepicker/testlibrary/infra/Discord4JEventTest.kt
@@ -1,0 +1,50 @@
+package com.tubefans.gamepicker.testlibrary.infra
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.event.domain.interaction.DeferrableInteractionEvent
+import discord4j.core.`object`.command.ApplicationCommandInteractionOption
+import discord4j.core.`object`.command.ApplicationCommandInteractionOptionValue
+import discord4j.core.spec.InteractionCallbackSpec
+import discord4j.core.spec.InteractionCallbackSpecDeferReplyMono
+import discord4j.core.spec.InteractionReplyEditMono
+import discord4j.core.spec.InteractionReplyEditSpec
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import reactor.core.publisher.Mono
+import java.util.*
+
+abstract class Discord4JEventTest {
+
+    @Mock
+    protected lateinit var inputEvent: ChatInputInteractionEvent
+
+    @Mock
+    protected lateinit var outputEvent: DeferrableInteractionEvent
+
+    @Mock
+    protected lateinit var option: ApplicationCommandInteractionOption
+
+    @Mock
+    protected lateinit var optionValue: ApplicationCommandInteractionOptionValue
+
+    @BeforeEach
+    fun eventSetup() {
+        MockitoAnnotations.openMocks(this)
+        Mockito.`when`(option.value).thenReturn(Optional.of(optionValue))
+        Mockito.`when`(inputEvent.options).thenReturn(listOf(option))
+        Mockito.`when`(inputEvent.deferReply()).thenReturn(InteractionCallbackSpecDeferReplyMono.of(outputEvent))
+        Mockito.`when`(inputEvent.editReply(ArgumentMatchers.any(InteractionReplyEditSpec::class.java)))
+            .thenReturn(Mono.empty())
+        Mockito.`when`(inputEvent.editReply(ArgumentMatchers.anyString())).thenReturn(InteractionReplyEditMono.of(outputEvent))
+        Mockito.`when`(inputEvent.deferReply(ArgumentMatchers.any(InteractionCallbackSpec::class.java)))
+            .thenReturn(Mono.empty())
+
+        Mockito.`when`(outputEvent.editReply(ArgumentMatchers.any(InteractionReplyEditSpec::class.java)))
+            .thenReturn(Mono.empty())
+        Mockito.`when`(outputEvent.deferReply(ArgumentMatchers.any(InteractionCallbackSpec::class.java)))
+            .thenReturn(Mono.empty())
+    }
+}


### PR DESCRIPTION
Add aws credentials as a dependency
Explicitly call gc() on handle()
Add getInstanceState()
Add getCommandMessageChannel()
Simplified chain
startInstance() now returns Mono
start/stop instance now handles reactive ec2Service methods
Updated StartServiceTest
Updated EC2ServiceTest
Added parent event test class
Added get-server command